### PR TITLE
Switch schemas to TypeBox

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,6 @@ import fs from "fs/promises";
 import path from "path";
 import os from 'os';
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 import { diffLines, createTwoFilesPatch } from 'diff';
 import { minimatch } from 'minimatch';
 import { XMLParser, XMLBuilder } from 'fast-xml-parser';
@@ -222,7 +221,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Handles various text encodings and provides detailed error messages " +
         "if the file cannot be read. Use this tool when you need to examine " +
         "the contents of a single file. Requires `maxBytes` parameter. Only works within allowed directories.",
-      inputSchema: zodToJsonSchema(ReadFileArgsSchema) as ToolInput,
+      inputSchema: ReadFileArgsSchema as unknown as ToolInput,
     },
     {
       name: "read_multiple_files",
@@ -232,7 +231,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "or compare multiple files. Each file's content is returned with its " +
         "path as a reference. Failed reads for individual files won't stop " +
         "the entire operation. Requires `maxBytesPerFile` parameter. Only works within allowed directories.",
-      inputSchema: zodToJsonSchema(ReadMultipleFilesArgsSchema) as ToolInput,
+      inputSchema: ReadMultipleFilesArgsSchema as unknown as ToolInput,
     },
     {
       name: "list_directory",
@@ -241,7 +240,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Results clearly distinguish between files and directories with [FILE] and [DIR] " +
         "prefixes. This tool is essential for understanding directory structure and " +
         "finding specific files within a directory. Only works within allowed directories.",
-      inputSchema: zodToJsonSchema(ListDirectoryArgsSchema) as ToolInput,
+      inputSchema: ListDirectoryArgsSchema as unknown as ToolInput,
     },
     {
       name: "directory_tree",
@@ -252,7 +251,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           "Files have no children array, while directories always have a children array (which may be empty). " +
           "Requires `maxDepth` parameter (default 2) to limit recursion. Use excludePatterns to filter out unwanted files/directories. " +
           "The output is formatted with 2-space indentation for readability. Only works within allowed directories.",
-      inputSchema: zodToJsonSchema(DirectoryTreeArgsSchema) as ToolInput,
+      inputSchema: DirectoryTreeArgsSchema as unknown as ToolInput,
     },
     {
       name: "search_files",
@@ -262,7 +261,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "is case-insensitive and matches partial names. Returns full paths to all " +
         "matching items. Requires `maxDepth` (default 2) and `maxResults` (default 10) parameters. Great for finding files when you don't know their exact location. " +
         "Only searches within allowed directories.",
-      inputSchema: zodToJsonSchema(SearchFilesArgsSchema) as ToolInput,
+      inputSchema: SearchFilesArgsSchema as unknown as ToolInput,
     },
     {
       name: "find_files_by_extension",
@@ -272,7 +271,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Extension matching is case-insensitive. Returns full paths to all " +
         "matching files. Requires `maxDepth` (default 2) and `maxResults` (default 10) parameters. Perfect for finding all XML, JSON, or other file types " +
         "in a directory structure. Only searches within allowed directories.",
-      inputSchema: zodToJsonSchema(FindFilesByExtensionArgsSchema) as ToolInput,
+      inputSchema: FindFilesByExtensionArgsSchema as unknown as ToolInput,
     },
     {
       name: "get_file_info",
@@ -281,7 +280,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "information including size, creation time, last modified time, permissions, " +
         "and type. This tool is perfect for understanding file characteristics " +
         "without reading the actual content. Only works within allowed directories.",
-      inputSchema: zodToJsonSchema(GetFileInfoArgsSchema) as ToolInput,
+      inputSchema: GetFileInfoArgsSchema as unknown as ToolInput,
     },
     {
       name: "list_allowed_directories",
@@ -303,7 +302,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "are allowed (create, edit, move, delete) and whether the server is in read-only mode " +
         "or has full access. Use this to understand what operations are permitted before " +
         "attempting them.",
-      inputSchema: zodToJsonSchema(GetPermissionsArgsSchema) as ToolInput,
+      inputSchema: GetPermissionsArgsSchema as unknown as ToolInput,
     },
     
     // Write tools (filtered based on permissions)
@@ -314,7 +313,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Will fail if the file already exists. " +
         "Only works within allowed directories. " +
         "This tool requires the --allow-create permission.",
-      inputSchema: zodToJsonSchema(WriteFileArgsSchema) as ToolInput,
+      inputSchema: WriteFileArgsSchema as unknown as ToolInput,
     },
     {
       name: "modify_file",
@@ -325,7 +324,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Will fail if the file does not exist. " +
         "Only works within allowed directories. " +
         "This tool requires the --allow-edit permission.",
-      inputSchema: zodToJsonSchema(WriteFileArgsSchema) as ToolInput,
+      inputSchema: WriteFileArgsSchema as unknown as ToolInput,
     },
     {
       name: "edit_file",
@@ -336,7 +335,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Returns a git-style diff showing the changes made. Requires `maxBytes` parameter (default 10KB) to limit initial read size. " +
         "Only works within allowed directories. " +
         "This tool requires the --allow-edit permission.",
-      inputSchema: zodToJsonSchema(EditFileArgsSchema) as ToolInput,
+      inputSchema: EditFileArgsSchema as unknown as ToolInput,
     },
     {
       name: "create_directory",
@@ -347,7 +346,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "COMPARE WITH move_file: create_directory creates new directories while move_file moves existing files/directories. " +
         "Only works within allowed directories. " +
         "This tool requires the --allow-create permission.",
-      inputSchema: zodToJsonSchema(CreateDirectoryArgsSchema) as ToolInput,
+      inputSchema: CreateDirectoryArgsSchema as unknown as ToolInput,
     },
     {
       name: "move_file",
@@ -358,7 +357,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "If the destination path already exists, the operation will fail. " +
         "Both source and destination must be within allowed directories. " +
         "This tool requires the --allow-move permission.",
-      inputSchema: zodToJsonSchema(MoveFileArgsSchema) as ToolInput,
+      inputSchema: MoveFileArgsSchema as unknown as ToolInput,
     },
     {
       name: "rename_file",
@@ -368,7 +367,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Will fail if a file with the new name already exists in the directory. " +
         "Only works within allowed directories. " +
         "This tool requires the --allow-rename permission.",
-      inputSchema: zodToJsonSchema(RenameFileArgsSchema) as ToolInput,
+      inputSchema: RenameFileArgsSchema as unknown as ToolInput,
     },
     {
       name: "xml_query",
@@ -378,7 +377,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Supports standard XPath 1.0 query syntax for finding elements, attributes, " +
         "and text content. Requires `maxBytes` parameter (default 10KB). Can be used to extract specific data from large XML files " +
         "with precise queries. The path must be within allowed directories.",
-      inputSchema: zodToJsonSchema(XmlQueryArgsSchema) as ToolInput,
+      inputSchema: XmlQueryArgsSchema as unknown as ToolInput,
     },
     {
       name: "xml_structure",
@@ -388,7 +387,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "namespaces, and hierarchical structure. Useful for understanding the " +
         "structure of large XML files before performing detailed queries. Requires `maxBytes` (default 10KB) and `maxDepth` (default 2) parameters. " +
         "The path must be within allowed directories.",
-      inputSchema: zodToJsonSchema(XmlStructureArgsSchema) as ToolInput,
+      inputSchema: XmlStructureArgsSchema as unknown as ToolInput,
     },
     {
       name: "xml_to_json",
@@ -400,7 +399,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "within allowed directories. " +
         "NOTE: Saving the output to a file requires the --allow-create or --allow-edit permission. Use xml_to_json_string for " +
         "read-only operations.",
-      inputSchema: zodToJsonSchema(XmlToJsonArgsSchema) as ToolInput,
+      inputSchema: XmlToJsonArgsSchema as unknown as ToolInput,
     },
     {
       name: "xml_to_json_string",
@@ -411,7 +410,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "The input path must be within allowed directories. " +
         "This tool is fully functional in both readonly and write modes (respecting maxBytes) since " +
         "it only reads the XML file and returns the parsed data.",
-      inputSchema: zodToJsonSchema(XmlToJsonStringArgsSchema) as ToolInput,
+      inputSchema: XmlToJsonStringArgsSchema as unknown as ToolInput,
     },
     {
       name: "delete_file",
@@ -421,7 +420,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Will fail if the file does not exist or if the path points to a directory. " +
         "Only works within allowed directories. " +
         "This tool requires the --allow-delete permission.",
-      inputSchema: zodToJsonSchema(DeleteFileArgsSchema) as ToolInput,
+      inputSchema: DeleteFileArgsSchema as unknown as ToolInput,
     },
     {
       name: "delete_directory",
@@ -431,7 +430,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "By default, will fail if the directory is not empty - set recursive=true to delete all contents. " +
         "Only works within allowed directories. " +
         "This tool requires the --allow-delete permission.",
-      inputSchema: zodToJsonSchema(DeleteDirectoryArgsSchema) as ToolInput,
+      inputSchema: DeleteDirectoryArgsSchema as unknown as ToolInput,
     },
     // JSON tools
     {
@@ -441,7 +440,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "capabilities for selecting data within JSON structures. Supports standard " +
         "JSONPath syntax for finding values, arrays, and nested structures. Requires `maxBytes` parameter (default 10KB). " +
         "The path must be within allowed directories.",
-      inputSchema: zodToJsonSchema(JsonQueryArgsSchema) as ToolInput,
+      inputSchema: JsonQueryArgsSchema as unknown as ToolInput,
     },
     {
       name: "json_structure",
@@ -451,7 +450,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "For arrays, it also indicates the type of the first element if available. " +
         "This is useful for understanding the shape of large JSON files without loading their entire content. Requires `maxBytes` (default 10KB) and `maxDepth` (default 2) parameters. " +
         "The path must be within allowed directories.",
-      inputSchema: zodToJsonSchema(JsonStructureArgsSchema) as ToolInput,
+      inputSchema: JsonStructureArgsSchema as unknown as ToolInput,
     },
     {
       name: "json_filter",
@@ -460,7 +459,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "operators (equals, greater than, contains, etc.) and can combine multiple " +
         "conditions with AND/OR logic. Requires `maxBytes` parameter (default 10KB). Perfect for filtering collections of objects " +
         "based on their properties. The path must be within allowed directories.",
-      inputSchema: zodToJsonSchema(JsonFilterArgsSchema) as ToolInput,
+      inputSchema: JsonFilterArgsSchema as unknown as ToolInput,
     },
     {
       name: "json_get_value",
@@ -468,7 +467,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Get a specific value from a JSON file using a field path. Supports dot notation " +
         "for accessing nested properties and array indices. Requires `maxBytes` parameter (default 10KB). Returns the value directly, " +
         "properly formatted. The path must be within allowed directories.",
-      inputSchema: zodToJsonSchema(JsonGetValueArgsSchema) as ToolInput,
+      inputSchema: JsonGetValueArgsSchema as unknown as ToolInput,
     },
     {
       name: "json_transform",
@@ -477,28 +476,28 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "mapping array elements, grouping by fields, sorting, flattening nested arrays, " +
         "and picking/omitting fields. Requires `maxBytes` parameter (default 10KB). Operations are applied in sequence to transform " +
         "the data structure. The path must be within allowed directories.",
-      inputSchema: zodToJsonSchema(JsonTransformArgsSchema) as ToolInput,
+      inputSchema: JsonTransformArgsSchema as unknown as ToolInput,
     },
     {
       name: "json_sample",
       description:
         "Sample JSON data from a JSON file. Requires `maxBytes` parameter (default 10KB). Returns a random sample of data from the JSON file. " +
         "The path must be within allowed directories.",
-      inputSchema: zodToJsonSchema(JsonSampleArgsSchema) as ToolInput,
+      inputSchema: JsonSampleArgsSchema as unknown as ToolInput,
     },
     {
       name: "json_validate",
       description:
         "Validate JSON data against a JSON schema. Requires `maxBytes` parameter (default 10KB) for the data file. Returns true if the JSON data is valid against the schema, " +
         "or false if it is not. The path must be within allowed directories.",
-      inputSchema: zodToJsonSchema(JsonValidateArgsSchema) as ToolInput,
+      inputSchema: JsonValidateArgsSchema as unknown as ToolInput,
     },
     {
       name: "json_search_kv",
       description:
         "Search for key-value pairs in JSON files within a directory. Requires `maxBytes` (default 10KB), `maxDepth` (default 2), and `maxResults` (default 10) parameters. Returns all key-value pairs that match the search pattern. " +
         "The path must be within allowed directories.",
-      inputSchema: zodToJsonSchema(JsonSearchKvArgsSchema) as ToolInput,
+      inputSchema: JsonSearchKvArgsSchema as unknown as ToolInput,
     },
     {
       name: "regex_search_content",
@@ -508,7 +507,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         "Returns a list of files containing matches, including line numbers and matching lines. " +
         "Requires `regex` pattern. Optional: `path`, `filePattern`, `maxDepth`, `maxFileSize`, `maxResults`. " +
         "Only searches within allowed directories.",
-      inputSchema: zodToJsonSchema(RegexSearchContentArgsSchema) as ToolInput,
+      inputSchema: RegexSearchContentArgsSchema as unknown as ToolInput,
     },
   ];
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "minimatch": "^10.0.1",
     "xmldom": "^0.6.0",
     "xpath": "^0.0.34",
+    "@sinclair/typebox": "^0.34.33",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.23.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 0.5.0
         version: 0.5.0
+      '@sinclair/typebox':
+        specifier: ^0.34.33
+        version: 0.34.33
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -356,6 +359,9 @@ packages:
     resolution: {integrity: sha512-yAkUOkIKZlK5dl7u6dg897doBgLXmUHhIINM2c+sND3DZwnrdQkkSiDh7N75Ll4mM4dxSkYfXqU9fW3lLkMFug==}
     cpu: [x64]
     os: [win32]
+
+  '@sinclair/typebox@0.34.33':
+    resolution: {integrity: sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g==}
 
   '@types/diff@5.2.3':
     resolution: {integrity: sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==}
@@ -1078,6 +1084,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.39.0':
     optional: true
+
+  '@sinclair/typebox@0.34.33': {}
 
   '@types/diff@5.2.3': {}
 

--- a/src/schemas/directory-operations.ts
+++ b/src/schemas/directory-operations.ts
@@ -1,20 +1,35 @@
-import { z } from "zod";
+import { Type, Static } from "@sinclair/typebox";
 
-export const CreateDirectoryArgsSchema = z.object({
-  path: z.string(),
+export const CreateDirectoryArgsSchema = Type.Object({
+  path: Type.String(),
 });
+export type CreateDirectoryArgs = Static<typeof CreateDirectoryArgsSchema>;
 
-export const ListDirectoryArgsSchema = z.object({
-  path: z.string(),
+export const ListDirectoryArgsSchema = Type.Object({
+  path: Type.String(),
 });
+export type ListDirectoryArgs = Static<typeof ListDirectoryArgsSchema>;
 
-export const DirectoryTreeArgsSchema = z.object({
-  path: z.string(),
-  maxDepth: z.number().int().positive().describe('Maximum depth to traverse. Must be a positive integer. Handler default: 2.'),
-  excludePatterns: z.array(z.string()).optional().default([]).describe('Glob patterns for files/directories to exclude (e.g., "*.log", "node_modules").')
+export const DirectoryTreeArgsSchema = Type.Object({
+  path: Type.String(),
+  maxDepth: Type.Integer({
+    minimum: 1,
+    description: 'Maximum depth to traverse. Must be a positive integer. Handler default: 2.'
+  }),
+  excludePatterns: Type.Optional(
+    Type.Array(Type.String(), {
+      default: [],
+      description: 'Glob patterns for files/directories to exclude (e.g., "*.log", "node_modules").'
+    })
+  )
 });
+export type DirectoryTreeArgs = Static<typeof DirectoryTreeArgsSchema>;
 
-export const DeleteDirectoryArgsSchema = z.object({
-  path: z.string(),
-  recursive: z.boolean().default(false).describe('Whether to recursively delete the directory and all contents')
-}); 
+export const DeleteDirectoryArgsSchema = Type.Object({
+  path: Type.String(),
+  recursive: Type.Boolean({
+    default: false,
+    description: 'Whether to recursively delete the directory and all contents'
+  })
+});
+export type DeleteDirectoryArgs = Static<typeof DeleteDirectoryArgsSchema>;

--- a/src/schemas/file-operations.ts
+++ b/src/schemas/file-operations.ts
@@ -1,53 +1,74 @@
-import { z } from "zod";
+import { Type, Static } from "@sinclair/typebox";
 
 // Schema definitions moved from index.ts
 
-export const ReadFileArgsSchema = z.object({
-  path: z.string(),
-  maxBytes: z.number().int().positive().describe('Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.')
+export const ReadFileArgsSchema = Type.Object({
+  path: Type.String(),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
+  })
 });
+export type ReadFileArgs = Static<typeof ReadFileArgsSchema>;
 
-export const ReadMultipleFilesArgsSchema = z.object({
-  paths: z.array(z.string()),
-  maxBytesPerFile: z.number().int().positive().describe('Maximum bytes to read per file. Must be a positive integer. Handler default: 10KB.')
+export const ReadMultipleFilesArgsSchema = Type.Object({
+  paths: Type.Array(Type.String()),
+  maxBytesPerFile: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read per file. Must be a positive integer. Handler default: 10KB.'
+  })
 });
+export type ReadMultipleFilesArgs = Static<typeof ReadMultipleFilesArgsSchema>;
 
 // Note: WriteFileArgsSchema is used by both create_file and modify_file
-export const WriteFileArgsSchema = z.object({
-  path: z.string(),
-  content: z.string(),
+export const WriteFileArgsSchema = Type.Object({
+  path: Type.String(),
+  content: Type.String(),
   // No maxBytes here as it's about writing, not reading limit
 });
+export type WriteFileArgs = Static<typeof WriteFileArgsSchema>;
 
-export const EditOperation = z.object({
-  oldText: z.string().describe('Text to search for - must match exactly'),
-  newText: z.string().describe('Text to replace with')
+export const EditOperation = Type.Object({
+  oldText: Type.String({ description: 'Text to search for - must match exactly' }),
+  newText: Type.String({ description: 'Text to replace with' })
 });
+export type EditOperationType = Static<typeof EditOperation>;
 
-export const EditFileArgsSchema = z.object({
-  path: z.string(),
-  edits: z.array(EditOperation),
-  dryRun: z.boolean().default(false).describe('Preview changes using git-style diff format'),
-  maxBytes: z.number().int().positive().describe('Maximum bytes to read from the file before editing. Must be a positive integer. Handler default: 10KB.')
+export const EditFileArgsSchema = Type.Object({
+  path: Type.String(),
+  edits: Type.Array(EditOperation),
+  dryRun: Type.Boolean({
+    default: false,
+    description: 'Preview changes using git-style diff format'
+  }),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the file before editing. Must be a positive integer. Handler default: 10KB.'
+  })
 });
+export type EditFileArgs = Static<typeof EditFileArgsSchema>;
 
-export const GetFileInfoArgsSchema = z.object({
-  path: z.string(),
+export const GetFileInfoArgsSchema = Type.Object({
+  path: Type.String(),
 });
+export type GetFileInfoArgs = Static<typeof GetFileInfoArgsSchema>;
 
-export const MoveFileArgsSchema = z.object({
-  source: z.string(),
-  destination: z.string(),
+export const MoveFileArgsSchema = Type.Object({
+  source: Type.String(),
+  destination: Type.String(),
 });
+export type MoveFileArgs = Static<typeof MoveFileArgsSchema>;
 
-export const DeleteFileArgsSchema = z.object({
-  path: z.string(),
+export const DeleteFileArgsSchema = Type.Object({
+  path: Type.String(),
 });
+export type DeleteFileArgs = Static<typeof DeleteFileArgsSchema>;
 
-export const RenameFileArgsSchema = z.object({
-  path: z.string().describe('Path to the file to be renamed'),
-  newName: z.string().describe('New name for the file (without path)')
+export const RenameFileArgsSchema = Type.Object({
+  path: Type.String({ description: 'Path to the file to be renamed' }),
+  newName: Type.String({ description: 'New name for the file (without path)' })
 });
+export type RenameFileArgs = Static<typeof RenameFileArgsSchema>;
 
 // Schemas previously defined in index.ts but related to other files (kept here for reference during refactor, but should be removed from index.ts)
 // export const GetPermissionsArgsSchema = z.object({}); // Moved to utility-operations.ts

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,4 +1,4 @@
 export * from './file-operations.js';
 export * from './directory-operations.js';
 export * from './utility-operations.js';
-export * from './json-operations.js'; 
+export * from './json-operations.js';

--- a/src/schemas/json-operations.ts
+++ b/src/schemas/json-operations.ts
@@ -1,113 +1,169 @@
-import { z } from "zod";
+import { Type, Static } from "@sinclair/typebox";
 
 // Schema for JSONPath query operations
-export const JsonQueryArgsSchema = z.object({
-  path: z.string().describe('Path to the JSON file to query'),
-  query: z.string().describe('JSONPath expression to execute against the JSON data'),
-  maxBytes: z.number().int().positive()
-    .describe('Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'),
+export const JsonQueryArgsSchema = Type.Object({
+  path: Type.String({ description: 'Path to the JSON file to query' }),
+  query: Type.String({ description: 'JSONPath expression to execute against the JSON data' }),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
+  })
 });
+export type JsonQueryArgs = Static<typeof JsonQueryArgsSchema>;
 
 // Schema for filtering JSON arrays
-export const JsonFilterArgsSchema = z.object({
-  path: z.string().describe('Path to the JSON file to filter'),
-  arrayPath: z.string().optional()
-    .describe('Optional JSONPath expression to locate the target array (e.g., "$.items" or "$.data.records")'),
-  conditions: z.array(z.object({
-    field: z.string().describe('Path to the field to check (e.g., "address.city" or "tags[0]")'),
-    operator: z.enum([
-      'eq', 'neq',  // equals, not equals
-      'gt', 'gte',  // greater than, greater than or equal
-      'lt', 'lte',  // less than, less than or equal
-      'contains',   // string/array contains
-      'startsWith', // string starts with
-      'endsWith',   // string ends with
-      'exists',     // field exists
-      'type'        // check value type
-    ]).describe('Comparison operator'),
-    value: z.any().describe('Value to compare against'),
-  })).min(1).describe('Array of filter conditions'),
-  match: z.enum(['all', 'any'])
-    .default('all')
-    .describe('How to combine multiple conditions - "all" for AND, "any" for OR'),
-  maxBytes: z.number().int().positive()
-    .describe('Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'),
+export const JsonFilterArgsSchema = Type.Object({
+  path: Type.String({ description: 'Path to the JSON file to filter' }),
+  arrayPath: Type.Optional(
+    Type.String({ description: 'Optional JSONPath expression to locate the target array (e.g., "$.items" or "$.data.records")' })
+  ),
+  conditions: Type.Array(
+    Type.Object({
+      field: Type.String({ description: 'Path to the field to check (e.g., "address.city" or "tags[0]")' }),
+      operator: Type.Union([
+        Type.Literal('eq'), Type.Literal('neq'),
+        Type.Literal('gt'), Type.Literal('gte'),
+        Type.Literal('lt'), Type.Literal('lte'),
+        Type.Literal('contains'),
+        Type.Literal('startsWith'),
+        Type.Literal('endsWith'),
+        Type.Literal('exists'),
+        Type.Literal('type')
+      ], { description: 'Comparison operator' }),
+      value: Type.Any({ description: 'Value to compare against' })
+    }),
+    { minItems: 1, description: 'Array of filter conditions' }
+  ),
+  match: Type.Optional(
+    Type.Union([Type.Literal('all'), Type.Literal('any')], {
+      default: 'all',
+      description: 'How to combine multiple conditions - "all" for AND, "any" for OR'
+    })
+  ),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
+  })
 });
+export type JsonFilterArgs = Static<typeof JsonFilterArgsSchema>;
 
 // Schema for getting a specific value from a JSON file
-export const JsonGetValueArgsSchema = z.object({
-  path: z.string().describe('Path to the JSON file'),
-  field: z.string().describe('Path to the field to retrieve (e.g., "user.address.city" or "items[0].name")'),
-  maxBytes: z.number().int().positive()
-    .describe('Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'),
+export const JsonGetValueArgsSchema = Type.Object({
+  path: Type.String({ description: 'Path to the JSON file' }),
+  field: Type.String({ description: 'Path to the field to retrieve (e.g., "user.address.city" or "items[0].name")' }),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
+  })
 });
+export type JsonGetValueArgs = Static<typeof JsonGetValueArgsSchema>;
 
 // Schema for transforming JSON data
-export const JsonTransformArgsSchema = z.object({
-  path: z.string().describe('Path to the JSON file to transform'),
-  operations: z.array(z.object({
-    type: z.enum([
-      'map',      // Transform array elements
-      'groupBy',  // Group array elements
-      'sort',     // Sort array elements
-      'flatten',  // Flatten nested arrays
-      'pick',     // Pick specific fields
-      'omit'      // Omit specific fields
-    ]).describe('Type of transformation operation'),
-    field: z.string().optional().describe('Field to operate on (if applicable)'),
-    order: z.enum(['asc', 'desc']).optional().describe('Sort order (if applicable)'),
-    fields: z.array(z.string()).optional().describe('Fields to pick/omit (if applicable)'),
-  })).min(1).describe('Array of transformation operations to apply in sequence'),
-  maxBytes: z.number().int().positive()
-    .describe('Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'),
+export const JsonTransformArgsSchema = Type.Object({
+  path: Type.String({ description: 'Path to the JSON file to transform' }),
+  operations: Type.Array(
+    Type.Object({
+      type: Type.Union([
+        Type.Literal('map'),
+        Type.Literal('groupBy'),
+        Type.Literal('sort'),
+        Type.Literal('flatten'),
+        Type.Literal('pick'),
+        Type.Literal('omit')
+      ], { description: 'Type of transformation operation' }),
+      field: Type.Optional(Type.String({ description: 'Field to operate on (if applicable)' })),
+      order: Type.Optional(Type.Union([Type.Literal('asc'), Type.Literal('desc')], { description: 'Sort order (if applicable)' })),
+      fields: Type.Optional(Type.Array(Type.String(), { description: 'Fields to pick/omit (if applicable)' }))
+    }),
+    { minItems: 1, description: 'Array of transformation operations to apply in sequence' }
+  ),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
+  })
 });
+export type JsonTransformArgs = Static<typeof JsonTransformArgsSchema>;
 
 // Schema for getting JSON structure
-export const JsonStructureArgsSchema = z.object({
-  path: z.string().describe('Path to the JSON file to analyze'),
-  maxBytes: z.number().int().positive()
-    .describe('Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'),
-  maxDepth: z.number().int().positive()
-    .describe('How deep to analyze the structure. Must be a positive integer. Handler default: 2.'),
-  detailedArrayTypes: z.boolean().optional().default(false)
-    .describe('Whether to analyze all array elements for mixed types (default: false)')
+export const JsonStructureArgsSchema = Type.Object({
+  path: Type.String({ description: 'Path to the JSON file to analyze' }),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
+  }),
+  maxDepth: Type.Integer({
+    minimum: 1,
+    description: 'How deep to analyze the structure. Must be a positive integer. Handler default: 2.'
+  }),
+  detailedArrayTypes: Type.Optional(Type.Boolean({
+    default: false,
+    description: 'Whether to analyze all array elements for mixed types (default: false)'
+  }))
 });
+export type JsonStructureArgs = Static<typeof JsonStructureArgsSchema>;
 
 // Schema for sampling JSON array elements
-export const JsonSampleArgsSchema = z.object({
-  path: z.string().describe('Path to the JSON file containing the array'),
-  arrayPath: z.string().describe('JSONPath expression to locate the target array (e.g., "$.items" or "$.data.records")'),
-  count: z.number().int().positive().describe('Number of elements to sample'),
-  method: z.enum(['first', 'random']).optional().default('first')
-    .describe('Sampling method - "first" for first N elements, "random" for random sampling'),
-  maxBytes: z.number().int().positive()
-    .describe('Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.')
+export const JsonSampleArgsSchema = Type.Object({
+  path: Type.String({ description: 'Path to the JSON file containing the array' }),
+  arrayPath: Type.String({ description: 'JSONPath expression to locate the target array (e.g., "$.items" or "$.data.records")' }),
+  count: Type.Integer({ minimum: 1, description: 'Number of elements to sample' }),
+  method: Type.Optional(
+    Type.Union([Type.Literal('first'), Type.Literal('random')], {
+      default: 'first',
+      description: 'Sampling method - "first" for first N elements, "random" for random sampling'
+    })
+  ),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
+  })
 });
+export type JsonSampleArgs = Static<typeof JsonSampleArgsSchema>;
 
 // Schema for JSON Schema validation
-export const JsonValidateArgsSchema = z.object({
-  path: z.string().describe('Path to the JSON file to validate'),
-  schemaPath: z.string().describe('Path to the JSON Schema file'),
-  maxBytes: z.number().int().positive()
-    .describe('Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'),
-  strict: z.boolean().optional().default(false)
-    .describe('Whether to enable strict mode validation (additionalProperties: false)'),
-  allErrors: z.boolean().optional().default(true)
-    .describe('Whether to collect all validation errors or stop at first error')
+export const JsonValidateArgsSchema = Type.Object({
+  path: Type.String({ description: 'Path to the JSON file to validate' }),
+  schemaPath: Type.String({ description: 'Path to the JSON Schema file' }),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
+  }),
+  strict: Type.Optional(Type.Boolean({
+    default: false,
+    description: 'Whether to enable strict mode validation (additionalProperties: false)'
+  })),
+  allErrors: Type.Optional(Type.Boolean({
+    default: true,
+    description: 'Whether to collect all validation errors or stop at first error'
+  }))
 });
+export type JsonValidateArgs = Static<typeof JsonValidateArgsSchema>;
 
 // Schema for searching JSON files by key/value pairs
-export const JsonSearchKvArgsSchema = z.object({
-  directoryPath: z.string().describe('Directory to search in'),
-  key: z.string().describe('Key to search for'),
-  value: z.any().optional().describe('Optional value to match against the key'),
-  recursive: z.boolean().optional().default(true)
-    .describe('Whether to search recursively in subdirectories'),
-  matchType: z.enum(['exact', 'contains', 'startsWith', 'endsWith']).optional().default('exact')
-    .describe('How to match values - only applies if value is provided'),
-  maxBytes: z.number().int().positive()
-    .describe('Maximum bytes to read from each file. Must be a positive integer. Handler default: 10KB.'),
-  maxResults: z.number().int().positive()
-    .describe('Maximum number of results to return. Must be a positive integer. Handler default: 10.'),
-  maxDepth: z.number().int().positive().describe('Maximum directory depth to search. Must be a positive integer. Handler default: 2.')
+export const JsonSearchKvArgsSchema = Type.Object({
+  directoryPath: Type.String({ description: 'Directory to search in' }),
+  key: Type.String({ description: 'Key to search for' }),
+  value: Type.Optional(Type.Any({ description: 'Optional value to match against the key' })),
+  recursive: Type.Optional(Type.Boolean({ default: true, description: 'Whether to search recursively in subdirectories' })),
+  matchType: Type.Optional(
+    Type.Union([
+      Type.Literal('exact'),
+      Type.Literal('contains'),
+      Type.Literal('startsWith'),
+      Type.Literal('endsWith')
+    ], { default: 'exact', description: 'How to match values - only applies if value is provided' })
+  ),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from each file. Must be a positive integer. Handler default: 10KB.'
+  }),
+  maxResults: Type.Integer({
+    minimum: 1,
+    description: 'Maximum number of results to return. Must be a positive integer. Handler default: 10.'
+  }),
+  maxDepth: Type.Integer({
+    minimum: 1,
+    description: 'Maximum directory depth to search. Must be a positive integer. Handler default: 2.'
+  })
 });
+export type JsonSearchKvArgs = Static<typeof JsonSearchKvArgsSchema>;

--- a/src/schemas/utility-operations.ts
+++ b/src/schemas/utility-operations.ts
@@ -1,70 +1,107 @@
-import { z } from "zod";
+import { Type, Static } from "@sinclair/typebox";
 
-export const GetPermissionsArgsSchema = z.object({});
+export const GetPermissionsArgsSchema = Type.Object({});
+export type GetPermissionsArgs = Static<typeof GetPermissionsArgsSchema>;
 
-export const SearchFilesArgsSchema = z.object({
-  path: z.string(),
-  pattern: z.string(),
-  excludePatterns: z.array(z.string()).optional().default([]),
-  maxDepth: z.number().int().positive().describe('Maximum directory depth to search. Must be a positive integer. Handler default: 2.'),
-  maxResults: z.number().int().positive().describe('Maximum number of results to return. Must be a positive integer. Handler default: 10.')
+export const SearchFilesArgsSchema = Type.Object({
+  path: Type.String(),
+  pattern: Type.String(),
+  excludePatterns: Type.Optional(
+    Type.Array(Type.String(), { default: [] })
+  ),
+  maxDepth: Type.Integer({
+    minimum: 1,
+    description: 'Maximum directory depth to search. Must be a positive integer. Handler default: 2.'
+  }),
+  maxResults: Type.Integer({
+    minimum: 1,
+    description: 'Maximum number of results to return. Must be a positive integer. Handler default: 10.'
+  })
 });
+export type SearchFilesArgs = Static<typeof SearchFilesArgsSchema>;
 
-export const FindFilesByExtensionArgsSchema = z.object({
-  path: z.string(),
-  extension: z.string().describe('File extension to search for (e.g., "xml", "json", "ts")'),
-  excludePatterns: z.array(z.string()).optional().default([]),
-  maxDepth: z.number().int().positive().describe('Maximum directory depth to search. Must be a positive integer. Handler default: 2.'),
-  maxResults: z.number().int().positive().describe('Maximum number of results to return. Must be a positive integer. Handler default: 10.')
+export const FindFilesByExtensionArgsSchema = Type.Object({
+  path: Type.String(),
+  extension: Type.String({ description: 'File extension to search for (e.g., "xml", "json", "ts")' }),
+  excludePatterns: Type.Optional(
+    Type.Array(Type.String(), { default: [] })
+  ),
+  maxDepth: Type.Integer({
+    minimum: 1,
+    description: 'Maximum directory depth to search. Must be a positive integer. Handler default: 2.'
+  }),
+  maxResults: Type.Integer({
+    minimum: 1,
+    description: 'Maximum number of results to return. Must be a positive integer. Handler default: 10.'
+  })
 });
+export type FindFilesByExtensionArgs = Static<typeof FindFilesByExtensionArgsSchema>;
 
-export const XmlToJsonArgsSchema = z.object({
-  xmlPath: z.string().describe('Path to the XML file to convert'),
-  jsonPath: z.string().describe('Path where the JSON should be saved'),
-  maxBytes: z.number().int().positive().describe('Maximum bytes to read from the XML file. Must be a positive integer. Handler default: 10KB.'),
-  options: z.object({
-    ignoreAttributes: z.boolean().default(false).describe('Whether to ignore attributes in XML'),
-    preserveOrder: z.boolean().default(true).describe('Whether to preserve the order of properties'),
-    format: z.boolean().default(true).describe('Whether to format the JSON output'),
-    indentSize: z.number().default(2).describe('Number of spaces for indentation')
-  }).optional().default({})
+export const XmlToJsonArgsSchema = Type.Object({
+  xmlPath: Type.String({ description: 'Path to the XML file to convert' }),
+  jsonPath: Type.String({ description: 'Path where the JSON should be saved' }),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the XML file. Must be a positive integer. Handler default: 10KB.'
+  }),
+  options: Type.Optional(
+    Type.Object({
+      ignoreAttributes: Type.Boolean({ default: false, description: 'Whether to ignore attributes in XML' }),
+      preserveOrder: Type.Boolean({ default: true, description: 'Whether to preserve the order of properties' }),
+      format: Type.Boolean({ default: true, description: 'Whether to format the JSON output' }),
+      indentSize: Type.Number({ default: 2, description: 'Number of spaces for indentation' })
+    }, { default: {} })
+  )
 });
+export type XmlToJsonArgs = Static<typeof XmlToJsonArgsSchema>;
 
-export const XmlToJsonStringArgsSchema = z.object({
-  xmlPath: z.string().describe('Path to the XML file to convert'),
-  maxBytes: z.number().int().positive().describe('Maximum bytes to read from the XML file. Must be a positive integer. Handler default: 10KB.'),
-  options: z.object({
-    ignoreAttributes: z.boolean().default(false).describe('Whether to ignore attributes in XML'),
-    preserveOrder: z.boolean().default(true).describe('Whether to preserve the order of properties')
-  }).optional().default({})
+export const XmlToJsonStringArgsSchema = Type.Object({
+  xmlPath: Type.String({ description: 'Path to the XML file to convert' }),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the XML file. Must be a positive integer. Handler default: 10KB.'
+  }),
+  options: Type.Optional(
+    Type.Object({
+      ignoreAttributes: Type.Boolean({ default: false, description: 'Whether to ignore attributes in XML' }),
+      preserveOrder: Type.Boolean({ default: true, description: 'Whether to preserve the order of properties' })
+    }, { default: {} })
+  )
 });
+export type XmlToJsonStringArgs = Static<typeof XmlToJsonStringArgsSchema>;
 
-export const XmlQueryArgsSchema = z.object({
-  path: z.string().describe('Path to the XML file to query'),
-  query: z.string().optional().describe('XPath query to execute against the XML file'),
-  structureOnly: z.boolean().optional().default(false)
-    .describe('If true, returns only tag names and structure instead of executing query'),
-  maxBytes: z.number().int().positive()
-    .describe('Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'),
-  includeAttributes: z.boolean().optional().default(true)
-    .describe('Whether to include attribute information in the results')
+export const XmlQueryArgsSchema = Type.Object({
+  path: Type.String({ description: 'Path to the XML file to query' }),
+  query: Type.Optional(Type.String({ description: 'XPath query to execute against the XML file' })),
+  structureOnly: Type.Optional(Type.Boolean({ default: false, description: 'If true, returns only tag names and structure instead of executing query' })),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
+  }),
+  includeAttributes: Type.Optional(Type.Boolean({ default: true, description: 'Whether to include attribute information in the results' }))
 });
+export type XmlQueryArgs = Static<typeof XmlQueryArgsSchema>;
 
-export const XmlStructureArgsSchema = z.object({
-  path: z.string().describe('Path to the XML file to analyze'),
-  maxDepth: z.number().int().positive()
-    .describe('How deep to analyze the hierarchy. Must be a positive integer. Handler default: 2.'),
-  includeAttributes: z.boolean().optional().default(true)
-    .describe('Whether to include attribute information'),
-  maxBytes: z.number().int().positive()
-    .describe('Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.')
+export const XmlStructureArgsSchema = Type.Object({
+  path: Type.String({ description: 'Path to the XML file to analyze' }),
+  maxDepth: Type.Integer({
+    minimum: 1,
+    description: 'How deep to analyze the hierarchy. Must be a positive integer. Handler default: 2.'
+  }),
+  includeAttributes: Type.Optional(Type.Boolean({ default: true, description: 'Whether to include attribute information' })),
+  maxBytes: Type.Integer({
+    minimum: 1,
+    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
+  })
 });
+export type XmlStructureArgs = Static<typeof XmlStructureArgsSchema>;
 
-export const RegexSearchContentArgsSchema = z.object({
-  path: z.string().describe('Directory path to start the search from.'),
-  regex: z.string().describe('The regular expression pattern to search for within file content.'),
-  filePattern: z.string().optional().default('*').describe('Glob pattern to filter files to search within (e.g., "*.ts", "data/**.json"). Defaults to searching all files.'),
-  maxDepth: z.number().int().positive().optional().default(2).describe('Maximum directory depth to search recursively. Defaults to 2.'),
-  maxFileSize: z.number().int().positive().optional().default(10 * 1024 * 1024).describe('Maximum file size in bytes to read for searching. Defaults to 10MB.'),
-  maxResults: z.number().int().positive().optional().default(50).describe('Maximum number of files with matches to return. Defaults to 50.')
+export const RegexSearchContentArgsSchema = Type.Object({
+  path: Type.String({ description: 'Directory path to start the search from.' }),
+  regex: Type.String({ description: 'The regular expression pattern to search for within file content.' }),
+  filePattern: Type.Optional(Type.String({ default: '*', description: 'Glob pattern to filter files to search within (e.g., "*.ts", "data/**.json"). Defaults to searching all files.' })),
+  maxDepth: Type.Optional(Type.Integer({ minimum: 1, default: 2, description: 'Maximum directory depth to search recursively. Defaults to 2.' })),
+  maxFileSize: Type.Optional(Type.Integer({ minimum: 1, default: 10 * 1024 * 1024, description: 'Maximum file size in bytes to read for searching. Defaults to 10MB.' })),
+  maxResults: Type.Optional(Type.Integer({ minimum: 1, default: 50, description: 'Maximum number of files with matches to return. Defaults to 50.' }))
 });
+export type RegexSearchContentArgs = Static<typeof RegexSearchContentArgsSchema>;


### PR DESCRIPTION
## Summary
- convert filesystem schemas from zod to `@sinclair/typebox`
- hook up typebox schemas in tool definitions
- clean up imports and add missing newlines

## Testing
- `pnpm exec tsc -p tsconfig.json`
- `pnpm exec vitest run` *(fails: connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68488423107483228a6f4120dba2414f