### PR TITLE
XML: Node DOM + response caps for xml_query/xml_structure

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,10 +6,12 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.12.1",
         "@sinclair/typebox": "^0.34.33",
+        "@sinclair/typemap": "^0.10.1",
+        "@xmldom/xmldom": "^0.9.8",
         "ajv": "^8.17.1",
         "diff": "^8.0.2",
         "fast-xml-parser": "^5.2.5",
-        "fastmcp": "3.4.0",
+        "fastmcp": "^3.14.1",
         "jsonata": "^2.0.6",
         "jsonpath-plus": "^10.3.0",
         "minimatch": "^10.0.1",
@@ -37,6 +39,8 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.33", "", {}, "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g=="],
 
+    "@sinclair/typemap": ["@sinclair/typemap@0.10.1", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.30", "valibot": "^1.0.0", "zod": "^3.24.1" } }, "sha512-UXR0fhu/n3c9B6lB+SLI5t1eVpt9i9CdDrp2TajRe3LbKiUhCTZN2kSfJhjPnpc3I59jMRIhgew7+0HlMi08mg=="],
+
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
@@ -54,6 +58,8 @@
     "@types/minimatch": ["@types/minimatch@5.1.2", "", {}, "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="],
 
     "@types/node": ["@types/node@22.15.31", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-jnVe5ULKl6tijxUhvQeNbQG/84fHfg+yMak02cT8QVhBx/F05rAVxCGBYYTh2EKz22D6JF5ktXuNwdx7b9iEGw=="],
+
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.9.8", "", {}, "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -135,7 +141,7 @@
 
     "fast-xml-parser": ["fast-xml-parser@5.2.5", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ=="],
 
-    "fastmcp": ["fastmcp@3.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.1", "@standard-schema/spec": "^1.0.0", "execa": "^9.6.0", "file-type": "^21.0.0", "fuse.js": "^7.1.0", "mcp-proxy": "^5.0.0", "strict-event-emitter-types": "^2.0.0", "undici": "^7.10.0", "uri-templates": "^0.2.0", "xsschema": "0.3.0-beta.3", "yargs": "^18.0.0", "zod": "^3.25.56", "zod-to-json-schema": "^3.24.5" }, "bin": { "fastmcp": "dist/bin/fastmcp.js" } }, "sha512-lsYGgrakp+1GYsdx2I6Fe0P24qiPMZd98VJ6YmpxqEjdVjee3BJpIFUzB4zj7WV6Lv3tZAOXU3yPIkAeE2yTtg=="],
+    "fastmcp": ["fastmcp@3.14.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.17.1", "@standard-schema/spec": "^1.0.0", "execa": "^9.6.0", "file-type": "^21.0.0", "fuse.js": "^7.1.0", "mcp-proxy": "^5.5.1", "strict-event-emitter-types": "^2.0.0", "undici": "^7.13.0", "uri-templates": "^0.2.0", "xsschema": "0.3.5", "yargs": "^18.0.0", "zod": "^3.25.76", "zod-to-json-schema": "^3.24.6" }, "bin": { "fastmcp": "dist/bin/fastmcp.js" } }, "sha512-XWIoIZqnG2tQc+Ck/gSO/IMB5ikCs7b/wwtsRXfcCudwT/+p8kvfboOFK/BTuTjmTpv4bf2UyeDhO/OQELfDGw=="],
 
     "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
@@ -201,7 +207,7 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "mcp-proxy": ["mcp-proxy@5.1.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.1", "eventsource": "^4.0.0", "yargs": "^18.0.0" }, "bin": { "mcp-proxy": "dist/bin/mcp-proxy.js" } }, "sha512-7FTIRIdHjZL7/sRBQ2/FiyQZDV3tJGBANJ9UV5VTiSaOOkDs8F1boY+EP4X/Blcme8eWVFjzmfx9LqdXA/ZHRQ=="],
+    "mcp-proxy": ["mcp-proxy@5.5.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.17.1", "eventsource": "^4.0.0", "yargs": "^18.0.0" }, "bin": { "mcp-proxy": "dist/bin/mcp-proxy.js" } }, "sha512-ScFtc0VjQl7NNzN88VkZYlOww5/RjiZPgLGrsl0hhktbJJSHqYiqbRUjzDSo3+XpYRhNM4ScaDF9Z4WZulfy1g=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
@@ -303,7 +309,7 @@
 
     "uint8array-extras": ["uint8array-extras@1.4.0", "", {}, "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ=="],
 
-    "undici": ["undici@7.10.0", "", {}, "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw=="],
+    "undici": ["undici@7.13.0", "", {}, "sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -315,6 +321,8 @@
 
     "uri-templates": ["uri-templates@0.2.0", "", {}, "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg=="],
 
+    "valibot": ["valibot@1.1.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -325,7 +333,7 @@
 
     "xpath": ["xpath@0.0.34", "", {}, "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA=="],
 
-    "xsschema": ["xsschema@0.3.0-beta.3", "", { "peerDependencies": { "@valibot/to-json-schema": "^1.0.0", "arktype": "^2.1.16", "effect": "^3.14.5", "sury": "^10.0.0-rc", "zod": "^3.25.0", "zod-to-json-schema": "^3.24.5" }, "optionalPeers": ["@valibot/to-json-schema", "arktype", "effect", "sury", "zod", "zod-to-json-schema"] }, "sha512-8fKI0Kqxs7npz3ElebNCeGdS0HDuS2qL3IqHK5O53yCdh419hcr3GQillwN39TNFasHjbMLQ+DjSwpY0NONdnQ=="],
+    "xsschema": ["xsschema@0.3.5", "", { "peerDependencies": { "@valibot/to-json-schema": "^1.0.0", "arktype": "^2.1.20", "effect": "^3.16.0", "sury": "^10.0.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.5" }, "optionalPeers": ["@valibot/to-json-schema", "arktype", "effect", "sury", "zod", "zod-to-json-schema"] }, "sha512-f+dcy11dTv7aBEEfTbXWnrm/1b/Ds2k4taN0TpN6KCtPAD58kyE/R1znUdrHdBnhIFexj9k+pS1fm6FgtSISrQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -341,10 +349,32 @@
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
+    "fastmcp/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.17.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-EFLRNXR/ixpXQWu6/3Cu30ndDFIFNaqUXcTqsGebujeMan9FzhAaFFswLRiFj61rgygDRr8WO1N+UijjgRxX9g=="],
+
+    "fastmcp/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "fastmcp/zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
+
+    "mcp-proxy/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.17.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-EFLRNXR/ixpXQWu6/3Cu30ndDFIFNaqUXcTqsGebujeMan9FzhAaFFswLRiFj61rgygDRr8WO1N+UijjgRxX9g=="],
+
     "mcp-proxy/eventsource": ["eventsource@4.0.0", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-fvIkb9qZzdMxgZrEQDyll+9oJsyaVvY92I2Re+qK0qEJ+w5s0X3dtz+M0VAPOjP1gtU3iqWyjQ0G3nvd5CLZ2g=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "fastmcp/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "mcp-proxy/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "mcp-proxy/@modelcontextprotocol/sdk/eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "mcp-proxy/@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "mcp-proxy/@modelcontextprotocol/sdk/zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
+
+    "fastmcp/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "mcp-proxy/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@modelcontextprotocol/sdk": "1.12.1",
     "@sinclair/typebox": "^0.34.33",
     "@sinclair/typemap": "^0.10.1",
+    "@xmldom/xmldom": "^0.9.8",
     "ajv": "^8.17.1",
     "diff": "^8.0.2",
     "fast-xml-parser": "^5.2.5",

--- a/src/schemas/utility-operations.ts
+++ b/src/schemas/utility-operations.ts
@@ -74,10 +74,14 @@ export const XmlQueryArgsSchema = Type.Object({
   path: Type.String({ description: 'Path to the XML file to query' }),
   query: Type.Optional(Type.String({ description: 'XPath query to execute against the XML file' })),
   structureOnly: Type.Optional(Type.Boolean({ default: false, description: 'If true, returns only tag names and structure instead of executing query' })),
-  maxBytes: Type.Integer({
+  maxBytes: Type.Optional(Type.Integer({
     minimum: 1,
-    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
-  }),
+    description: '[Deprecated semantics] Previously limited file bytes read; now treated as a response size cap in bytes.'
+  })),
+  maxResponseBytes: Type.Optional(Type.Integer({
+    minimum: 1,
+    description: 'Maximum size, in bytes, of the returned content. Parsing reads full file; response may be truncated to respect this limit.'
+  })),
   includeAttributes: Type.Optional(Type.Boolean({ default: true, description: 'Whether to include attribute information in the results' }))
 });
 export type XmlQueryArgs = Static<typeof XmlQueryArgsSchema>;
@@ -89,10 +93,14 @@ export const XmlStructureArgsSchema = Type.Object({
     description: 'How deep to analyze the hierarchy. Must be a positive integer. Handler default: 2.'
   }),
   includeAttributes: Type.Optional(Type.Boolean({ default: true, description: 'Whether to include attribute information' })),
-  maxBytes: Type.Integer({
+  maxBytes: Type.Optional(Type.Integer({
     minimum: 1,
-    description: 'Maximum bytes to read from the file. Must be a positive integer. Handler default: 10KB.'
-  })
+    description: '[Deprecated semantics] Previously limited file bytes read; now treated as a response size cap in bytes.'
+  })),
+  maxResponseBytes: Type.Optional(Type.Integer({
+    minimum: 1,
+    description: 'Maximum size, in bytes, of the returned content. Parsing reads full file; response may be truncated to respect this limit.'
+  }))
 });
 export type XmlStructureArgs = Static<typeof XmlStructureArgsSchema>;
 

--- a/src/schemas/utility-operations.ts
+++ b/src/schemas/utility-operations.ts
@@ -40,10 +40,14 @@ export type FindFilesByExtensionArgs = Static<typeof FindFilesByExtensionArgsSch
 export const XmlToJsonArgsSchema = Type.Object({
   xmlPath: Type.String({ description: 'Path to the XML file to convert' }),
   jsonPath: Type.String({ description: 'Path where the JSON should be saved' }),
-  maxBytes: Type.Integer({
+  maxBytes: Type.Optional(Type.Integer({
     minimum: 1,
-    description: 'Maximum bytes to read from the XML file. Must be a positive integer. Handler default: 10KB.'
-  }),
+    description: '[Deprecated semantics] Previously limited file bytes read; ignored for parsing; considered only as a response size cap where applicable.'
+  })),
+  maxResponseBytes: Type.Optional(Type.Integer({
+    minimum: 1,
+    description: 'Maximum size, in bytes, of the returned content. Parsing reads full file; response may be truncated to respect this limit.'
+  })),
   options: Type.Optional(
     Type.Object({
       ignoreAttributes: Type.Boolean({ default: false, description: 'Whether to ignore attributes in XML' }),
@@ -57,10 +61,14 @@ export type XmlToJsonArgs = Static<typeof XmlToJsonArgsSchema>;
 
 export const XmlToJsonStringArgsSchema = Type.Object({
   xmlPath: Type.String({ description: 'Path to the XML file to convert' }),
-  maxBytes: Type.Integer({
+  maxBytes: Type.Optional(Type.Integer({
     minimum: 1,
-    description: 'Maximum bytes to read from the XML file. Must be a positive integer. Handler default: 10KB.'
-  }),
+    description: '[Deprecated semantics] Previously limited file bytes read; now treated as a response size cap in bytes.'
+  })),
+  maxResponseBytes: Type.Optional(Type.Integer({
+    minimum: 1,
+    description: 'Maximum size, in bytes, of the returned JSON string. Parsing reads full file; response may be truncated to respect this limit.'
+  })),
   options: Type.Optional(
     Type.Object({
       ignoreAttributes: Type.Boolean({ default: false, description: 'Whether to ignore attributes in XML' }),

--- a/src/utils/path-utils.ts
+++ b/src/utils/path-utils.ts
@@ -11,7 +11,16 @@ export function normalizePath(p: string): string {
 export function expandHome(filepath: string): string {
   // Expand $VAR, ${VAR}, and %VAR% environment variables
   let expanded = filepath.replace(/\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))|%([A-Za-z_][A-Za-z0-9_]*)%/g, (match, braced, unixVar, winVar) => {
-    const envVar = braced || unixVar || winVar;
+    const envVar = (braced || unixVar || winVar) as string;
+
+    // Built-in fallbacks for common CWD variables
+    if (envVar === 'CWD') {
+      return process.cwd();
+    }
+    if (envVar === 'PWD') {
+      return process.env.PWD ?? process.cwd();
+    }
+
     const value = process.env[envVar];
     if (value === undefined) {
       throw new Error(`Environment variable ${envVar} is not defined`);

--- a/test/suites/xml_tools/xml_tools.test.ts
+++ b/test/suites/xml_tools/xml_tools.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { ClientCapabilities, CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import path from 'path';
+import fs from 'fs/promises';
+import { fileURLToPath } from 'url';
+
+const clientInfo = { name: 'xml-tools-test-suite', version: '0.1.0' };
+const clientCapabilities: ClientCapabilities = { toolUse: { enabled: true } };
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverRoot = path.resolve(__dirname, '../../fs_root');
+const serverCommand = 'bun';
+const serverArgs = ['dist/index.js', serverRoot, '--full-access'];
+const basePath = 'xml_tools/';
+
+function getTextContent(result: unknown): string {
+  const parsed = CallToolResultSchema.parse(result);
+  const first = parsed.content[0];
+  if (!first || first.type !== 'text') throw new Error('Expected text content');
+  return (first as any).text as string;
+}
+
+describe('test-filesystem::xml_tools', () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    await fs.mkdir(serverRoot, { recursive: true });
+    transport = new StdioClientTransport({ command: serverCommand, args: serverArgs });
+    client = new Client(clientInfo, { capabilities: clientCapabilities });
+    await client.connect(transport);
+
+    await client.callTool({ name: 'create_directory', arguments: { path: basePath } });
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+      `<catalog xmlns="http://example.org/catalog">\n` +
+      `  <book id="bk101" category="fiction">\n` +
+      `    <author>Gambardella, Matthew</author>\n` +
+      `    <title>XML Developer's Guide</title>\n` +
+      `  </book>\n` +
+      `  <book id="bk102" category="fiction">\n` +
+      `    <author>Ralls, Kim</author>\n` +
+      `    <title>Midnight Rain</title>\n` +
+      `  </book>\n` +
+      `</catalog>\n`;
+
+    await client.callTool({ name: 'create_file', arguments: { path: `${basePath}basic.xml`, content: xml } });
+
+    // Create a larger XML to exercise truncation
+    const manyBooks = Array.from({ length: 200 }, (_, i) => `  <book id="bk${1000 + i}"><title>T${i}</title></book>`).join('\n');
+    const bigXml = `<?xml version="1.0"?><catalog xmlns="http://example.org/catalog">\n${manyBooks}\n</catalog>\n`;
+    await client.callTool({ name: 'create_file', arguments: { path: `${basePath}big.xml`, content: bigXml } });
+  });
+
+  afterAll(async () => {
+    await client.callTool({ name: 'delete_directory', arguments: { path: basePath, recursive: true } });
+    await transport.close();
+  });
+
+  it('xml_structure returns structure for a basic XML', async () => {
+    const res = await client.callTool({ name: 'xml_structure', arguments: { path: `${basePath}basic.xml`, maxDepth: 2, includeAttributes: true, maxResponseBytes: 1024 * 1024 } }, CallToolResultSchema);
+    expect(res.isError).not.toBe(true);
+    const text = getTextContent(res);
+    const obj = JSON.parse(text);
+    expect(obj.rootElement).toBe('catalog');
+    expect(typeof obj.elements).toBe('object');
+    expect(obj.namespaces).toBeDefined();
+  });
+
+  it('xml_query supports XPath with local-name() (namespace-agnostic)', async () => {
+    const res = await client.callTool({ name: 'xml_query', arguments: { path: `${basePath}basic.xml`, query: "//*[local-name()='title']/text()", includeAttributes: true, maxResponseBytes: 50 * 1024 } }, CallToolResultSchema);
+    expect(res.isError).not.toBe(true);
+    const text = getTextContent(res);
+    const arr = JSON.parse(text);
+    expect(Array.isArray(arr)).toBe(true);
+    // Expect at least two titles
+    expect(arr.length).toBeGreaterThanOrEqual(2);
+    expect(arr[0].type).toBeDefined();
+  });
+
+  it('xml_structure truncates output when exceeding maxResponseBytes', async () => {
+    const res = await client.callTool({ name: 'xml_structure', arguments: { path: `${basePath}big.xml`, maxDepth: 2, includeAttributes: false, maxResponseBytes: 300 } }, CallToolResultSchema);
+    expect(res.isError).not.toBe(true);
+    const text = getTextContent(res);
+    const obj = JSON.parse(text);
+    expect(obj._meta?.truncated).toBe(true);
+  });
+
+  it('xml_query truncates output when exceeding maxResponseBytes', async () => {
+    const res = await client.callTool({ name: 'xml_query', arguments: { path: `${basePath}big.xml`, query: "//*[local-name()='book']", includeAttributes: true, maxResponseBytes: 400 } }, CallToolResultSchema);
+    expect(res.isError).not.toBe(true);
+    const text = getTextContent(res);
+    // Either includes meta or a small array; ensure length is not huge
+    expect(text.length).toBeLessThanOrEqual(400 + 200); // allow small overhead
+  });
+
+  it('xml_to_json_string returns JSON and applies response cap when small', async () => {
+    const res = await client.callTool({ name: 'xml_to_json_string', arguments: { xmlPath: `${basePath}big.xml`, maxResponseBytes: 500 } }, CallToolResultSchema);
+    expect(res.isError).not.toBe(true);
+    const jsonText = getTextContent(res);
+    const parsed = JSON.parse(jsonText);
+    expect(parsed._meta?.truncated).toBe(true);
+  });
+
+  it('xml_to_json writes a file and applies response cap when small', async () => {
+    const outPath = `${basePath}out.json`;
+    const res = await client.callTool({ name: 'xml_to_json', arguments: { xmlPath: `${basePath}big.xml`, jsonPath: outPath, maxResponseBytes: 600, options: { format: true } } }, CallToolResultSchema);
+    expect(res.isError).not.toBe(true);
+    const read = await client.callTool({ name: 'read_file', arguments: { path: outPath, maxBytes: 100000 } }, CallToolResultSchema);
+    const jsonText = getTextContent(read);
+    const parsed = JSON.parse(jsonText);
+    expect(parsed._meta?.truncated).toBe(true);
+  });
+});
+
+


### PR DESCRIPTION
- Replace global DOMParser with @xmldom/xmldom for Node compatibility.
- Parse full files; cap only response size (new optional maxResponseBytes; legacy maxBytes as response cap).
- Implement truncation for xml_query and xml_structure with metadata.
- Keep fast-xml-parser for xml_to_json.

Build/tests green.